### PR TITLE
Improve regex for flavour detection

### DIFF
--- a/lib/fastlane/plugin/get_application_id_flavor/actions/get_application_id_action_flavor.rb
+++ b/lib/fastlane/plugin/get_application_id_flavor/actions/get_application_id_action_flavor.rb
@@ -53,7 +53,7 @@ module Fastlane
         else
           begin
             File.open(path) do |f|
-              match = f.read.scan(/#{flavor} \{([^}]+)\}/).first
+              match = f.read.scan(/#{flavor} \{([^}]+)\}/).last
               line = match.first.strip.split(/\n/).select { |l| l.include? constant_name }.first
               components = line.strip.split(' ')
               application_id = components.last.tr("\"'", '')


### PR DESCRIPTION
when having defined something like

```
signingConfigs {
        release {
            Properties props = new Properties()
            props.load(new FileInputStream("signing.properties"))
            storeFile = file(props['STORE_FILE'])
            storePassword = props['STORE_PASSWORD']
            keyAlias = props['KEY_ALIAS']
            keyPassword = props['KEY_PASSWORD']
        }
        flavorX {
            Properties props = new Properties()
            props.load(new FileInputStream("flavorX.signing.properties"))
            storeFile = file(props['STORE_FILE'])
            storePassword = props['STORE_PASSWORD']
            keyAlias = props['KEY_ALIAS']
            keyPassword = props['KEY_PASSWORD']
        }
    }
```

to load custom signing properties, the plugin would use that first block instead of the actual `flavorX` blog defined in `productFlavors`