### PR TITLE
Fix for bad flavor match when flavor contains another flavor name as suffix

### DIFF
--- a/lib/fastlane/plugin/get_application_id_flavor/actions/get_application_id_action_flavor.rb
+++ b/lib/fastlane/plugin/get_application_id_flavor/actions/get_application_id_action_flavor.rb
@@ -53,7 +53,7 @@ module Fastlane
         else
           begin
             File.open(path) do |f|
-              match = f.read.scan(/#{flavor} \{([^}]+)\}/).last
+              match = f.read.scan(/^\s*#{flavor}\s*\{([^}]+)\}/).last
               line = match.first.strip.split(/\n/).select { |l| l.include? constant_name }.first
               components = line.strip.split(' ')
               application_id = components.last.tr("\"'", '')


### PR DESCRIPTION
This commit fixes bad matches when a flavor name contains another flavor name as suffix.

Example gradle snippet:
```
productFlavors {
        bar {
            dimension "test"
            applicationId "i.am.bar"
        }
        foobar {
            dimension "test"
            applicationId "i.am.foobar"
        }
}
``` 

In this case `get_application_id(flavor: "bar")` should return `"i.am.bar"`, but it returns `"i.am.foobar"` since the last match for `/#{flavor} {...` is taken. This also matches the `foobar {` line since it contains the searched suffix `bar {`.

**Fix:**
The regex has to ensure that there is only the line beginning and some whitespace before the the flavor name (and no other alphanumeric characters) in order not to match suffixes by accident.